### PR TITLE
ALA-6

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
   <br>
 
-**A modern RESTful API for book management built with Spring Boot**
+**A modern RESTful API for book management built with Spring Boot 3, Java 21 and Hexagonal Architecture**
 
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-6DB33F?style=flat-square&logo=spring-boot&logoColor=white)](https://spring.io/projects/spring-boot)
 [![Spring Data JPA](https://img.shields.io/badge/Spring%20Data%20JPA-6DB33F?style=flat-square&logo=spring&logoColor=white)](https://spring.io/projects/spring-data-jpa)
@@ -129,17 +129,19 @@ End-to-end purchase flow:
 - Maven 3.8+
 - PostgreSQL 15+ (or use Docker)
 
-### � Installation & Setup
+### 🛠️ Installation & Setup
 
 #### Option 1: Docker Compose (Recommended)
 
 1. **Clone the repository**
+
    ```bash
    git clone https://github.com/brunoliratm/ArchivumLibris-API.git
    cd ArchivumLibris-API
    ```
 
 2. **Start with Docker Compose**
+
    ```bash
    docker-compose up --build -d
    ```
@@ -152,17 +154,20 @@ End-to-end purchase flow:
 #### Option 2: Manual Setup
 
 1. **Clone the repository**
+
    ```bash
    git clone https://github.com/brunoliratm/ArchivumLibris-API.git
    cd ArchivumLibris-API
    ```
 
 2. **Setup PostgreSQL database**
+
    ```sql
    CREATE DATABASE ala;
    ```
 
 3. **Configure environment variables** (optional)
+
    ```bash
    export SPRING_DATASOURCE_URL=localhost:5432/ala
    export SPRING_DATASOURCE_USERNAME=postgres
@@ -173,6 +178,7 @@ End-to-end purchase flow:
    ```
 
 4. **Build and run the application**
+
    ```bash
    # Build the project
    ./mvnw clean install
@@ -180,16 +186,18 @@ End-to-end purchase flow:
    # Run the application
    ./mvnw spring-boot:run
    ```
-   
+
 ### 🚀 How to Run
 
 1. **Start the application** using one of the methods above
 2. **Access the API endpoints:**
+
    - **API Base URL:** http://localhost:8080
    - **Swagger UI:** http://localhost:8080/swagger-ui.html
    - **API Documentation:** http://localhost:8080/v3/api-docs
 
 3. **Login with default admin credentials:**
+
    - **Email:** admin@email.com
    - **Password:** admin2025@
 
@@ -218,7 +226,6 @@ The application uses Flyway for database migrations with the following main tabl
 - **users** - User accounts with roles and soft delete
 - **books** - Book catalog with metadata and pricing
 - **purchases** - Purchase transactions linking users and books
-
 
 ## 🐳 Docker Support
 
@@ -278,3 +285,7 @@ Distributed under the MIT License. See [`LICENSE`](LICENSE) for more information
 ## 📮 Contact
 
 **Project Link:** [https://github.com/brunoliratm/ArchivumLibris-API](https://github.com/brunoliratm/ArchivumLibris-API)
+
+**Author:** Bruno Lira
+**LinkedIn:** [brunoliratm](https://www.linkedin.com/in/brunoliratm/)
+**GitHub:** [@brunoliratm](https://github.com/brunoliratm)

--- a/README.md
+++ b/README.md
@@ -267,6 +267,63 @@ docker run --name archivumlibris-api \
   -d archivumlibris-api
 ```
 
+## 📦 Example Requests
+
+### Create a Book
+
+```http
+POST /api/books
+Content-Type: application/json
+
+{
+  "title": "Clean Code",
+  "author": "Robert C. Martin",
+  "publisher": "Prentice Hall",
+  "genre": "NON_FICTION",
+  "price": 99.90
+}
+```
+
+### Register a User
+
+```http
+POST /api/auth/register
+Content-Type: application/json
+
+{
+  "name": "Alice",
+  "email": "alice@email.com",
+  "password": "secret123"
+}
+```
+
+### Purchase a Book
+
+```http
+POST /api/purchases
+Content-Type: application/json
+Authorization: Bearer <JWT_TOKEN>
+
+{
+  "bookId": 1,
+  "payMethod": "PIX"
+}
+```
+
+## 🧪 Running Tests
+
+To run all unit and integration tests:
+
+```bash
+./mvnw test
+```
+
+## 📝 Troubleshooting
+
+- **Database connection issues:** Check your environment variables and Docker Compose logs.
+- **Port conflicts:** Ensure ports 8080 (API) and 5432 (Postgres) are free.
+- **Swagger not loading:** Wait for the backend to finish starting or check logs for errors.
+
 ## 🤝 Contributing
 
 Contributions make the open source community an amazing place to learn, inspire, and create. Any contributions you make
@@ -289,3 +346,4 @@ Distributed under the MIT License. See [`LICENSE`](LICENSE) for more information
 **Author:** Bruno Lira
 **LinkedIn:** [brunoliratm](https://www.linkedin.com/in/brunoliratm/)
 **GitHub:** [@brunoliratm](https://github.com/brunoliratm)
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   api:
     build: .
@@ -10,7 +8,7 @@ services:
       - db
     environment:
       - SPRING_PROFILES_ACTIVE=docker
-      - SPRING_DATASOURCE_URL=db:5432/ala
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/ala
       - SPRING_DATASOURCE_USERNAME=postgres
       - SPRING_DATASOURCE_PASSWORD=postgres
       - JWT_SECRET=archivumlibris_jwt_secret_for_development_only

--- a/src/main/java/com/archivumlibris/adapter/in/auth/AuthController.java
+++ b/src/main/java/com/archivumlibris/adapter/in/auth/AuthController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -106,6 +107,7 @@ public class AuthController {
                             content = @Content(mediaType = "application/json",
                                     examples = @ExampleObject(
                                             value = "{\"message\": \"User not found\"}")))})
+    @GetMapping("/userinfo")
     public ResponseEntity<UserResponseDTO> userInfo() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         User user = (User) authentication.getPrincipal();

--- a/src/main/java/com/archivumlibris/adapter/in/auth/AuthController.java
+++ b/src/main/java/com/archivumlibris/adapter/in/auth/AuthController.java
@@ -107,12 +107,16 @@ public class AuthController {
                             content = @Content(mediaType = "application/json",
                                     examples = @ExampleObject(
                                             value = "{\"message\": \"User not found\"}")))})
-    @GetMapping("/userinfo")
+    @GetMapping("/me")
     public ResponseEntity<UserResponseDTO> userInfo() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        User user = (User) authentication.getPrincipal();
-        return this.userUseCase.findById(user.getId()).map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+        Object principal = authentication != null ? authentication.getPrincipal() : null;
+        if (principal instanceof User user) {
+            return this.userUseCase.findById(user.getId()).map(ResponseEntity::ok)
+                    .orElse(ResponseEntity.notFound().build());
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
     }
 
 }

--- a/src/main/java/com/archivumlibris/adapter/in/auth/AuthController.java
+++ b/src/main/java/com/archivumlibris/adapter/in/auth/AuthController.java
@@ -1,20 +1,25 @@
 package com.archivumlibris.adapter.in.auth;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import com.archivumlibris.domain.port.in.auth.AuthUseCase;
-import com.archivumlibris.dto.request.auth.AuthRequestDTO;
-import com.archivumlibris.dto.request.user.UserRequestDTO;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.archivumlibris.domain.model.user.User;
+import com.archivumlibris.domain.port.in.auth.AuthUseCase;
+import com.archivumlibris.domain.port.in.user.UserUseCase;
+import com.archivumlibris.dto.request.auth.AuthRequestDTO;
+import com.archivumlibris.dto.request.user.UserRequestDTO;
+import com.archivumlibris.dto.response.user.UserResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 
 @RestController
@@ -23,9 +28,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 public class AuthController {
 
     private final AuthUseCase authUseCase;
+    private final UserUseCase userUseCase;
 
-    public AuthController(AuthUseCase authUseCase) {
+    public AuthController(AuthUseCase authUseCase, UserUseCase userUseCase) {
         this.authUseCase = authUseCase;
+        this.userUseCase = userUseCase;
     }
 
     @Operation(summary = "Register new user",
@@ -49,7 +56,7 @@ public class AuthController {
     @PostMapping("/register")
     public ResponseEntity<String> register(@RequestBody @Valid UserRequestDTO userRequestDTO) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .header("Authorization", "Bearer " + this.authUseCase.registerUser(userRequestDTO))
+                .header("Authorization", "Bearer " + this.authUseCase.register(userRequestDTO))
                 .build();
     }
 
@@ -80,5 +87,30 @@ public class AuthController {
                 .build();
     }
 
+    @Operation(summary = "Get current user info",
+            description = "Returns information about the currently authenticated user.",
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            description = "User info returned successfully."),
+                    @ApiResponse(responseCode = "401",
+                            description = "Unauthorized (missing or invalid token)",
+                            content = @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = "{\"message\": \"Unauthorized access. Authentication required.\"}"))),
+                    @ApiResponse(responseCode = "403",
+                            description = "Access denied (insufficient permission or invalid token)",
+                            content = @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = "{\"message\": \"Access denied: you do not have permission to access this resource.\"}"))),
+                    @ApiResponse(responseCode = "404", description = "User not found.",
+                            content = @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = "{\"message\": \"User not found\"}")))})
+    public ResponseEntity<UserResponseDTO> userInfo() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        return this.userUseCase.findById(user.getId()).map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
 
 }

--- a/src/main/java/com/archivumlibris/adapter/in/purchase/PurchaseController.java
+++ b/src/main/java/com/archivumlibris/adapter/in/purchase/PurchaseController.java
@@ -23,8 +23,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-
-
 @RestController
 @RequestMapping("/api/purchases")
 @Tag(name = "Purchases", description = "Endpoints for purchase management")
@@ -73,7 +71,11 @@ public class PurchaseController {
     @PostMapping
     public ResponseEntity<Void> create(@Valid @RequestBody PurchaseRequestDTO purchaseRequestDTO) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        User user = (User) authentication.getPrincipal();
+        Object principal = authentication != null ? authentication.getPrincipal() : null;
+        if (!(principal instanceof User)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        User user = (User) principal;
         this.purchaseUseCase.create(user.getId(), purchaseRequestDTO);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/com/archivumlibris/application/service/auth/AuthService.java
+++ b/src/main/java/com/archivumlibris/application/service/auth/AuthService.java
@@ -32,7 +32,7 @@ public class AuthService implements AuthUseCase {
 
     @Override
     @Transactional
-    public String registerUser(UserRequestDTO userRequestDTO) {
+    public String register(UserRequestDTO userRequestDTO) {
         this.userService.create(userRequestDTO);
         return login(new AuthRequestDTO(userRequestDTO.email(), userRequestDTO.password()));
     }
@@ -71,4 +71,5 @@ public class AuthService implements AuthUseCase {
             throw new RuntimeException("Error during login");
         }
     }
+
 }

--- a/src/main/java/com/archivumlibris/application/service/purchase/PurchaseService.java
+++ b/src/main/java/com/archivumlibris/application/service/purchase/PurchaseService.java
@@ -41,8 +41,8 @@ public class PurchaseService implements PurchaseUseCase {
     }
 
     @Override
-    public void create(PurchaseRequestDTO purchaseRequestDTO) {
-        User user = userRepositoryPort.findById(purchaseRequestDTO.userId())
+    public void create(Long userId, PurchaseRequestDTO purchaseRequestDTO) {
+        User user = userRepositoryPort.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
         Book book = bookRepositoryPort.findById(purchaseRequestDTO.bookId())

--- a/src/main/java/com/archivumlibris/domain/port/in/auth/AuthUseCase.java
+++ b/src/main/java/com/archivumlibris/domain/port/in/auth/AuthUseCase.java
@@ -5,7 +5,7 @@ import com.archivumlibris.dto.request.user.UserRequestDTO;
 
 public interface AuthUseCase {
 
-    public String registerUser(UserRequestDTO userRequestDTO);
+    public String register(UserRequestDTO userRequestDTO);
 
     public String login(AuthRequestDTO authRequestDTO);
 

--- a/src/main/java/com/archivumlibris/domain/port/in/purchase/PurchaseUseCase.java
+++ b/src/main/java/com/archivumlibris/domain/port/in/purchase/PurchaseUseCase.java
@@ -7,7 +7,7 @@ import com.archivumlibris.dto.response.purchase.PurchaseResponseDTO;
 
 public interface PurchaseUseCase {
 
-    void create(PurchaseRequestDTO purchaseRequestDTO);
+    void create(Long userId, PurchaseRequestDTO purchaseRequestDTO);
 
     List<PurchaseResponseDTO> findAll(String payMethod, Long bookId, int page);
 

--- a/src/main/java/com/archivumlibris/dto/request/purchase/PurchaseRequestDTO.java
+++ b/src/main/java/com/archivumlibris/dto/request/purchase/PurchaseRequestDTO.java
@@ -6,10 +6,6 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 
 public record PurchaseRequestDTO(
-    @NotNull(message = "User ID is required")
-    @Positive(message = "User ID must be greater than 0")
-    Long userId,
-
     @NotNull(message = "Book ID is required")
     @Positive(message = "Book ID must be greater than 0")
     Long bookId,

--- a/src/main/java/com/archivumlibris/security/config/SecurityConfig.java
+++ b/src/main/java/com/archivumlibris/security/config/SecurityConfig.java
@@ -26,15 +26,15 @@ public class SecurityConfig {
                 .sessionManagement(
                         sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth.requestMatchers(HttpMethod.POST, "/api/auth/**")
-                        .permitAll().
-                        requestMatchers(HttpMethod.GET, "/api/auth/**").authenticated()
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
-                        .permitAll().requestMatchers(HttpMethod.GET, "/api/books/**").permitAll()
+                        .permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/auth/**").authenticated()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/books/**").permitAll()
                         .requestMatchers("/api/books/**").hasAuthority("ADMIN")
                         .requestMatchers("/api/users/**").hasAuthority("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/purchases/**").authenticated()
-                        .requestMatchers("/api/purchases/**").hasAuthority("ADMIN").anyRequest()
-                        .authenticated())
+                        .requestMatchers("/api/purchases/**").hasAuthority("ADMIN")
+                        .anyRequest().authenticated())
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(authenticationEntryHandler)
                         .accessDeniedHandler(accessDeniedHandler))
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class).build();

--- a/src/main/java/com/archivumlibris/security/config/SecurityConfig.java
+++ b/src/main/java/com/archivumlibris/security/config/SecurityConfig.java
@@ -7,9 +7,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import com.archivumlibris.security.jwt.JwtFilter;
-import com.archivumlibris.security.handler.CustomAuthenticationEntryHandler;
 import com.archivumlibris.security.handler.CustomAccessDeniedHandler;
+import com.archivumlibris.security.handler.CustomAuthenticationEntryHandler;
+import com.archivumlibris.security.jwt.JwtFilter;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -25,13 +25,16 @@ public class SecurityConfig {
         return http.csrf(csrf -> csrf.disable())
                 .sessionManagement(
                         sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth.requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/books/**").permitAll()
+                .authorizeHttpRequests(auth -> auth.requestMatchers(HttpMethod.POST, "/api/auth/**")
+                        .permitAll().
+                        requestMatchers(HttpMethod.GET, "/api/auth/**").authenticated()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
+                        .permitAll().requestMatchers(HttpMethod.GET, "/api/books/**").permitAll()
                         .requestMatchers("/api/books/**").hasAuthority("ADMIN")
                         .requestMatchers("/api/users/**").hasAuthority("ADMIN")
-                        .requestMatchers("/api/purchases/**").hasAuthority("ADMIN")
-                        .anyRequest().authenticated())
+                        .requestMatchers(HttpMethod.POST, "/api/purchases/**").authenticated()
+                        .requestMatchers("/api/purchases/**").hasAuthority("ADMIN").anyRequest()
+                        .authenticated())
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(authenticationEntryHandler)
                         .accessDeniedHandler(accessDeniedHandler))
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class).build();

--- a/src/test/java/com/archivumlibris/services/AuthServiceTest.java
+++ b/src/test/java/com/archivumlibris/services/AuthServiceTest.java
@@ -1,0 +1,135 @@
+package com.archivumlibris.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import com.archivumlibris.application.service.auth.AuthService;
+import com.archivumlibris.application.service.user.UserService;
+import com.archivumlibris.domain.model.user.User;
+import com.archivumlibris.dto.request.auth.AuthRequestDTO;
+import com.archivumlibris.dto.request.user.UserRequestDTO;
+import com.archivumlibris.security.jwt.TokenService;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AuthService authservice;
+
+    private User activeUser;
+
+    @BeforeEach
+    void setUp() {
+        activeUser = new User();
+        activeUser.setId(1L);
+        activeUser.setName("Test User");
+        activeUser.setEmail("test@example.com");
+        activeUser.setPassword("encodedPassword");
+    }
+
+    @Test
+    void testRegisterReturnsToken() {
+        UserRequestDTO userRequestDTO =
+                new UserRequestDTO("Test User", "test@example.com", "password123");
+        AuthRequestDTO authRequestDTO = new AuthRequestDTO("test@example.com", "password123");
+
+        doNothing().when(userService).create(userRequestDTO);
+        when(userService.findByEmail("test@example.com"))
+                .thenReturn(java.util.Optional.of(activeUser)); 
+        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
+        when(tokenService.createToken(authRequestDTO)).thenReturn("mockedToken");
+
+        String token = authservice.register(userRequestDTO);
+
+        assertEquals("mockedToken", token);
+        verify(userService).create(userRequestDTO);
+        verify(tokenService).createToken(authRequestDTO);
+    }
+
+    @Test
+    void testLoginReturnsToken() {
+        AuthRequestDTO authRequestDTO = new AuthRequestDTO("test@example.com", "password123");
+        when(tokenService.createToken(authRequestDTO)).thenReturn("mockedToken");
+        when(userService.findByEmail("test@example.com"))
+                .thenReturn(java.util.Optional.of(activeUser));
+        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
+
+        String token = authservice.login(authRequestDTO);
+
+        assertEquals("mockedToken", token);
+        verify(tokenService).createToken(authRequestDTO);
+    }
+
+    @Test
+    void testLoginThrowsExceptionForInvalidEmailFormat() {
+        AuthRequestDTO authRequestDTO = new AuthRequestDTO("invalid-email", "password123");
+        Exception exception =
+                assertThrows(com.archivumlibris.shared.exception.InvalidDataException.class, () -> {
+                    authservice.login(authRequestDTO);
+                });
+        assertTrue(exception.getMessage().contains("Invalid email format"));
+    }
+
+    @Test
+    void testLoginThrowsExceptionForUserNotFound() {
+        AuthRequestDTO authRequestDTO = new AuthRequestDTO("notfound@example.com", "password123");
+        when(userService.findByEmail("notfound@example.com"))
+                .thenReturn(java.util.Optional.empty());
+        Exception exception =
+                assertThrows(com.archivumlibris.exception.user.UserNotFoundException.class, () -> {
+                    authservice.login(authRequestDTO);
+                });
+        assertTrue(exception.getMessage().contains("User not found"));
+    }
+
+    @Test
+    void testLoginThrowsExceptionForWrongPassword() {
+        AuthRequestDTO authRequestDTO = new AuthRequestDTO("test@example.com", "wrongpassword");
+        when(userService.findByEmail("test@example.com"))
+                .thenReturn(java.util.Optional.of(activeUser));
+        when(passwordEncoder.matches("wrongpassword", "encodedPassword")).thenReturn(false);
+
+        Exception exception =
+                assertThrows(com.archivumlibris.shared.exception.InvalidDataException.class, () -> {
+                    authservice.login(authRequestDTO);
+                });
+        assertTrue(exception.getMessage().contains("Invalid email or password"));
+    }
+
+    @Test
+    void testLoginThrowsExceptionForNullEmailOrPassword() {
+        AuthRequestDTO authRequestDTO = new AuthRequestDTO(null, null);
+        Exception exception =
+                assertThrows(com.archivumlibris.shared.exception.InvalidDataException.class, () -> {
+                    authservice.login(authRequestDTO);
+                });
+        assertTrue(exception.getMessage().contains("Email and password are required"));
+    }
+}

--- a/src/test/java/com/archivumlibris/services/BookServiceTest.java
+++ b/src/test/java/com/archivumlibris/services/BookServiceTest.java
@@ -1,0 +1,125 @@
+package com.archivumlibris.services;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import com.archivumlibris.application.service.book.BookService;
+import com.archivumlibris.domain.model.book.Book;
+import com.archivumlibris.domain.model.book.BookGenre;
+import com.archivumlibris.domain.port.out.book.BookRepositoryPort;
+import com.archivumlibris.dto.request.book.BookRequestDTO;
+import com.archivumlibris.dto.response.book.BookResponseDTO;
+import com.archivumlibris.exception.book.BookNotFoundException;
+import com.archivumlibris.shared.exception.InvalidDataException;
+
+class BookServiceTest {
+
+    @Mock
+    private BookRepositoryPort bookRepositoryPort;
+
+    @InjectMocks
+    private BookService bookService;
+
+    private Book book;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        book = new Book(1L, "Title", "Author", "Publisher", BookGenre.FICTION,
+                BigDecimal.valueOf(10));
+    }
+
+    @Test
+    void testCreateBookSuccess() {
+        BookRequestDTO dto = new BookRequestDTO("Title", "Author", "Publisher", "FICTION",
+                BigDecimal.valueOf(10));
+        doNothing().when(bookRepositoryPort).save(any(Book.class));
+        assertDoesNotThrow(() -> bookService.create(dto));
+    }
+
+    @Test
+    void testCreateBookInvalidData() {
+        BookRequestDTO dto =
+                new BookRequestDTO("", "Author", "Publisher", "FICTION", BigDecimal.valueOf(10));
+        assertThrows(InvalidDataException.class, () -> bookService.create(dto));
+    }
+
+    @Test
+    void testUpdateBookSuccess() {
+        BookRequestDTO dto = new BookRequestDTO("Title", "Author", "Publisher", "FICTION",
+                BigDecimal.valueOf(10));
+        when(bookRepositoryPort.findById(1L)).thenReturn(Optional.of(book));
+        assertDoesNotThrow(() -> bookService.update(1L, dto));
+    }
+
+    @Test
+    void testUpdateBookNotFound() {
+        BookRequestDTO dto = new BookRequestDTO("Title", "Author", "Publisher", "FICTION",
+                BigDecimal.valueOf(10));
+        when(bookRepositoryPort.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(BookNotFoundException.class, () -> bookService.update(1L, dto));
+    }
+
+    @Test
+    void testDeleteBookSuccess() {
+        when(bookRepositoryPort.findById(1L)).thenReturn(Optional.of(book));
+        assertDoesNotThrow(() -> bookService.delete(1L));
+    }
+
+    @Test
+    void testDeleteBookNotFound() {
+        when(bookRepositoryPort.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(BookNotFoundException.class, () -> bookService.delete(1L));
+    }
+
+    @Test
+    void testFindByIdSuccess() {
+        when(bookRepositoryPort.findById(1L)).thenReturn(Optional.of(book));
+        Optional<BookResponseDTO> result = bookService.findById(1L);
+        assertTrue(result.isPresent());
+        assertEquals("Title", result.get().title());
+    }
+
+    @Test
+    void testFindByIdNotFound() {
+        when(bookRepositoryPort.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(BookNotFoundException.class, () -> bookService.findById(1L));
+    }
+
+    @Test
+    void testFindAllSuccess() {
+        Page<Book> page = new PageImpl<>(List.of(book));
+        when(bookRepositoryPort.findAll(any(), any(), any(), any(), any(Pageable.class)))
+                .thenReturn(page);
+        List<BookResponseDTO> result =
+                bookService.findAll("FICTION", "Title", "Publisher", "Author", 1);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void testFindAllInvalidPage() {
+        assertThrows(com.archivumlibris.shared.exception.InvalidPageException.class,
+                () -> bookService.findAll("FICTION", "Title", "Publisher", "Author", 0));
+    }
+
+    @Test
+    void testFindAllInvalidGenre() {
+        assertThrows(InvalidDataException.class,
+                () -> bookService.findAll("INVALID_GENRE", "Title", "Publisher", "Author", 1));
+    }
+}

--- a/src/test/java/com/archivumlibris/services/PurchaseServiceTest.java
+++ b/src/test/java/com/archivumlibris/services/PurchaseServiceTest.java
@@ -1,0 +1,125 @@
+package com.archivumlibris.services;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import com.archivumlibris.application.service.purchase.PurchaseService;
+import com.archivumlibris.domain.model.book.Book;
+import com.archivumlibris.domain.model.purchase.PayMethod;
+import com.archivumlibris.domain.model.purchase.Purchase;
+import com.archivumlibris.domain.model.user.User;
+import com.archivumlibris.domain.port.out.book.BookRepositoryPort;
+import com.archivumlibris.domain.port.out.purchase.PurchaseRepositoryPort;
+import com.archivumlibris.domain.port.out.user.UserRepositoryPort;
+import com.archivumlibris.dto.request.purchase.PurchaseRequestDTO;
+import com.archivumlibris.dto.response.purchase.PurchaseResponseDTO;
+import com.archivumlibris.exception.book.BookNotFoundException;
+import com.archivumlibris.exception.purchase.PurchaseNotFoundException;
+import com.archivumlibris.exception.user.UserNotFoundException;
+import com.archivumlibris.shared.exception.InvalidDataException;
+import com.archivumlibris.shared.exception.InvalidPageException;
+
+class PurchaseServiceTest {
+
+    @Mock
+    private PurchaseRepositoryPort purchaseRepositoryPort;
+    @Mock
+    private BookRepositoryPort bookRepositoryPort;
+    @Mock
+    private UserRepositoryPort userRepositoryPort;
+
+    @InjectMocks
+    private PurchaseService purchaseService;
+
+    private User user;
+    private Book book;
+    private Purchase purchase;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        user = new User(1L, "User", "user@email.com", "pass",
+                com.archivumlibris.domain.model.user.UserRole.USER, false);
+        book = new Book(1L, "Title", "Author", "Publisher",
+                com.archivumlibris.domain.model.book.BookGenre.FICTION, BigDecimal.valueOf(10));
+        purchase = new Purchase(1L, LocalDate.now(), PayMethod.PIX, BigDecimal.valueOf(10), book,
+                user);
+    }
+
+    @Test
+    void testCreatePurchaseSuccess() {
+        PurchaseRequestDTO dto = new PurchaseRequestDTO(1L, "PIX");
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.of(user));
+        when(bookRepositoryPort.findById(1L)).thenReturn(Optional.of(book));
+        assertDoesNotThrow(() -> purchaseService.create(1L, dto));
+    }
+
+    @Test
+    void testCreatePurchaseUserNotFound() {
+        PurchaseRequestDTO dto = new PurchaseRequestDTO(1L, "PIX");
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(UserNotFoundException.class, () -> purchaseService.create(1L, dto));
+    }
+
+    @Test
+    void testCreatePurchaseBookNotFound() {
+        PurchaseRequestDTO dto = new PurchaseRequestDTO(1L, "PIX");
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.of(user));
+        when(bookRepositoryPort.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(BookNotFoundException.class, () -> purchaseService.create(1L, dto));
+    }
+
+    @Test
+    void testCreatePurchaseInvalidPayMethod() {
+        PurchaseRequestDTO dto = new PurchaseRequestDTO(1L, "INVALID");
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.of(user));
+        when(bookRepositoryPort.findById(1L)).thenReturn(Optional.of(book));
+        assertThrows(InvalidDataException.class, () -> purchaseService.create(1L, dto));
+    }
+
+    @Test
+    void testFindAllSuccess() {
+        Page<Purchase> page = new PageImpl<>(List.of(purchase));
+        when(purchaseRepositoryPort.findAll(any(), any(), any(Pageable.class))).thenReturn(page);
+        List<PurchaseResponseDTO> result = purchaseService.findAll("PIX", 1L, 1);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void testFindAllInvalidPage() {
+        assertThrows(InvalidPageException.class, () -> purchaseService.findAll("PIX", 1L, 0));
+    }
+
+    @Test
+    void testFindAllInvalidPayMethod() {
+        assertThrows(InvalidDataException.class, () -> purchaseService.findAll("INVALID", 1L, 1));
+    }
+
+    @Test
+    void testFindByIdSuccess() {
+        when(purchaseRepositoryPort.findById(1L)).thenReturn(Optional.of(purchase));
+        Optional<PurchaseResponseDTO> result = purchaseService.findById(1L);
+        assertTrue(result.isPresent());
+    }
+
+    @Test
+    void testFindByIdNotFound() {
+        when(purchaseRepositoryPort.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(PurchaseNotFoundException.class, () -> purchaseService.findById(1L));
+    }
+}

--- a/src/test/java/com/archivumlibris/services/UserServiceTest.java
+++ b/src/test/java/com/archivumlibris/services/UserServiceTest.java
@@ -1,0 +1,135 @@
+package com.archivumlibris.services;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import com.archivumlibris.application.service.user.UserService;
+import com.archivumlibris.domain.model.user.User;
+import com.archivumlibris.domain.model.user.UserRole;
+import com.archivumlibris.domain.port.out.user.UserRepositoryPort;
+import com.archivumlibris.dto.request.user.UserPatchRequestDTO;
+import com.archivumlibris.dto.request.user.UserRequestDTO;
+import com.archivumlibris.dto.response.user.UserResponseDTO;
+import com.archivumlibris.exception.user.UserNotFoundException;
+import com.archivumlibris.shared.exception.InvalidDataException;
+import com.archivumlibris.shared.exception.InvalidPageException;
+
+class UserServiceTest {
+
+    @Mock
+    private UserRepositoryPort userRepositoryPort;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        user = new User(1L, "User", "user@email.com", "pass", UserRole.USER, false);
+    }
+
+    @Test
+    void testCreateUserSuccess() {
+        UserRequestDTO dto = new UserRequestDTO("User", "user@email.com", "pass123");
+        when(userRepositoryPort.findByEmail("user@email.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded");
+        assertDoesNotThrow(() -> userService.create(dto));
+    }
+
+    @Test
+    void testCreateUserEmailAlreadyExists() {
+        UserRequestDTO dto = new UserRequestDTO("User", "user@email.com", "pass123");
+        when(userRepositoryPort.findByEmail("user@email.com")).thenReturn(Optional.of(user));
+        assertThrows(InvalidDataException.class, () -> userService.create(dto));
+    }
+
+    @Test
+    void testUpdateUserSuccess() {
+        UserPatchRequestDTO dto = new UserPatchRequestDTO("NewName", "new@email.com", "newpass");
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepositoryPort.findByEmail("new@email.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded");
+        assertDoesNotThrow(() -> userService.update(1L, dto));
+    }
+
+    @Test
+    void testUpdateUserNotFound() {
+        UserPatchRequestDTO dto = new UserPatchRequestDTO("NewName", "new@email.com", "newpass");
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(UserNotFoundException.class, () -> userService.update(1L, dto));
+    }
+
+    @Test
+    void testDeleteUserSuccess() {
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.of(user));
+        assertDoesNotThrow(() -> userService.delete(1L));
+    }
+
+    @Test
+    void testDeleteUserNotFound() {
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(UserNotFoundException.class, () -> userService.delete(1L));
+    }
+
+    @Test
+    void testFindByIdSuccess() {
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.of(user));
+        Optional<UserResponseDTO> result = userService.findById(1L);
+        assertTrue(result.isPresent());
+        assertEquals("User", result.get().name());
+    }
+
+    @Test
+    void testFindByIdNotFound() {
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(UserNotFoundException.class, () -> userService.findById(1L));
+    }
+
+    @Test
+    void testFindAllSuccess() {
+        Page<User> page = new PageImpl<>(List.of(user));
+        when(userRepositoryPort.findAll(any(), any(), any(Pageable.class))).thenReturn(page);
+        List<UserResponseDTO> result = userService.findAll("User", "user@email.com", 1);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void testFindAllInvalidPage() {
+        assertThrows(InvalidPageException.class,
+                () -> userService.findAll("User", "user@email.com", 0));
+    }
+
+    @Test
+    void testLoadUserByEmailSuccess() {
+        when(userRepositoryPort.findByEmail("user@email.com")).thenReturn(Optional.of(user));
+        assertNotNull(userService.loadUserByEmail("user@email.com"));
+    }
+
+    @Test
+    void testLoadUserByEmailNotFound() {
+        when(userRepositoryPort.findByEmail("user@email.com")).thenReturn(Optional.empty());
+        assertThrows(UsernameNotFoundException.class,
+                () -> userService.loadUserByEmail("user@email.com"));
+    }
+}


### PR DESCRIPTION
This pull request introduces several improvements to authentication, user info retrieval, and purchase handling in the API. The main changes include adding an endpoint to fetch the current user's information, updating the purchase flow to use the authenticated user's ID, and refactoring method signatures and DTOs to better align with these changes. Security configurations have also been updated to properly restrict access to endpoints.

**Authentication and User Info Improvements**
* Added a new `userInfo` endpoint in `AuthController` to return details of the currently authenticated user, leveraging Spring Security for authentication context.
* Updated `AuthController` and related interfaces/services to use a single `register` method for user registration, simplifying the naming and usage. [[1]](diffhunk://#diff-e934e64c75c8cb0214b9f7fd06a592e9d7403bf6151e77f60c56387ee758f777L52-R59) [[2]](diffhunk://#diff-3418753079ae735efa6e92bd4c330d6af7c80f910d0056d509a69c40a16a692cL35-R35) [[3]](diffhunk://#diff-59e32d62c0586635e9dd2a850285620d5abec116acb6d715975f4cbc051ff541L8-R8)

**Purchase Flow Refactor**
* Modified the purchase creation process to use the authenticated user's ID from the security context, removing the need for `userId` in the request DTO and updating method signatures accordingly. [[1]](diffhunk://#diff-050cd7b2bfb20e313841d4f7e2eb1349aa11a35cd39b5d009d84ba9805030a27L72-R77) [[2]](diffhunk://#diff-06d147d3bd3f82ab93ec2a5bb6ee9867dc8e556a8976e3df724b43a8292eb9f4L44-R45) [[3]](diffhunk://#diff-314eed058d5c6d6987dc1eabe2e57dbd23851eac15a9248439f5fa527b7c37b4L10-R10) [[4]](diffhunk://#diff-c6459fccd674d73c9d3d7370e4a31ec4dd580a0cebcc0400d0530bc0637ca03dL9-L12)

**Security Configuration Updates**
* Updated security rules to require authentication for GET requests to `/api/auth/**`, and for POST requests to `/api/purchases/**`, while keeping admin restrictions for other purchase endpoints.
* Minor reordering of imports for clarity in `SecurityConfig`.